### PR TITLE
Use the official way of detected dev mode

### DIFF
--- a/main.py
+++ b/main.py
@@ -41,5 +41,5 @@ application = webapp2.WSGIApplication([
         ('/', HomePage),
         ('/admin/?', AdminPage),
     ],
-    debug = os.environ.get('APPLICATION_ID', 'dev~').startswith('dev~')
+    debug = not os.getenv('SERVER_SOFTWARE', '').startswith('Google App Engine/')
 )


### PR DESCRIPTION
Various ways "work", but https://cloud.google.com/appengine/docs/standard/python/tools/using-local-server#detecting_application_runtime_environment is authoritative

